### PR TITLE
Fix code scanning alert no. 23: Database query built from user-controlled sources

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -12,7 +12,7 @@ const login = async (req = request, res = response) => {
 
 	try {
 		// Verify if the email exists
-		const usuario = await Usuario.findOne({ correo });
+		const usuario = await Usuario.findOne({ correo: { $eq: correo } });
 		if (!usuario) {
 			return res.status(400).json({
 				msg: 'User / Password are not correct - email',


### PR DESCRIPTION
Fixes [https://github.com/Juan-Camilo-Sanchez-Echeverri/ms-usuarios/security/code-scanning/23](https://github.com/Juan-Camilo-Sanchez-Echeverri/ms-usuarios/security/code-scanning/23)

To fix the problem, we need to ensure that the user-provided `correo` value is treated as a literal value in the MongoDB query. This can be achieved by using the `$eq` operator to ensure that the value is interpreted correctly and not as a query object. This change will prevent potential NoSQL injection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
