### PR TITLE
Fix code scanning alert no. 22: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,23 +6,24 @@
 	"main": "app.js",
 	"scripts": {
 		"start": "node app.js",
-		"dev" : "nodemon app.js",
+		"dev": "nodemon app.js",
 		"test": "echo \"Error: no test specified\" && exit 1"
-	},
-	"keywords": [],
-	"author": "",
-	"license": "ISC",
-	"dependencies": {
-		"bcryptjs": "^2.4.3",
-		"cors": "^2.8.5",
-		"dotenv": "^16.3.1",
-		"express": "^4.21.2",
-		"express-validator": "^7.0.1",
-		"google-auth-library": "^9.0.0",
-		"jsonwebtoken": "^9.0.2",
-		"mongoose": "^8.8.3"
-	},
-	"devDependencies": {
-		"@flydotio/dockerfile": "^0.4.10"
-	}
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
+    "express": "^4.21.2",
+    "express-validator": "^7.0.1",
+    "google-auth-library": "^9.0.0",
+    "jsonwebtoken": "^9.0.2",
+    "mongoose": "^8.8.3",
+    "express-rate-limit": "^7.5.0"
+  },
+  "devDependencies": {
+    "@flydotio/dockerfile": "^0.4.10"
+  }
 }

--- a/routes/usuarios.js
+++ b/routes/usuarios.js
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { check } from 'express-validator';
+import RateLimit from 'express-rate-limit';
 
 
 import { esAdminRole, tieneRole, validarJWT, validarCampos } from "../middlewares/index.js";
@@ -16,6 +17,11 @@ import {
 
 
 const router = Router();
+
+const limiter = RateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // max 100 requests per windowMs
+});
 
 router.get('/', [
 	check('limite', "El valor de 'limite' debe ser numérico")
@@ -47,6 +53,7 @@ router.put('/:id', [
 router.patch('/', usuariosPatch);
 
 router.delete('/:id', [
+	limiter,
 	validarJWT,
 	// esAdminRole,
 	tieneRole('ADMIN_ROLE', 'VENTAS_ROLE'),


### PR DESCRIPTION
Fixes [https://github.com/Juan-Camilo-Sanchez-Echeverri/ms-usuarios/security/code-scanning/22](https://github.com/Juan-Camilo-Sanchez-Echeverri/ms-usuarios/security/code-scanning/22)

To fix the problem, we need to introduce rate limiting to the `usuariosDelete` route handler. The best way to do this is by using the `express-rate-limit` package, which allows us to easily set up rate limiting middleware. We will configure the rate limiter to allow a maximum of 100 requests per 15 minutes and apply it to the `usuariosDelete` route.

We need to:
1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `routes/usuarios.js` file.
3. Set up the rate limiter middleware.
4. Apply the rate limiter middleware to the `usuariosDelete` route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
