### PR TITLE
Fix code scanning alert no. 17: Missing rate limiting

### DIFF
--- a/routes/categorias.js
+++ b/routes/categorias.js
@@ -4,12 +4,15 @@ import { check } from 'express-validator';
 import { esAdminRole, validarCampos, validarJWT } from '../middlewares/index.js';
 import { actualizarCategoria, borrarCategoria, crearCategoria, obtenerCategoria, obtenerCategorias } from '../controllers/categorias.js';
 import { existeCategoriaPorId } from '../helpers/db-validators.js';
+import RateLimit from 'express-rate-limit';
 
-
-
+const limiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
 const router = Router();
 
-
+router.use(limiter);
 router.get('/', obtenerCategorias)
 
 router.get('/:id', [


### PR DESCRIPTION
Fixes [https://github.com/Juan-Camilo-Sanchez-Echeverri/ms-usuarios/security/code-scanning/17](https://github.com/Juan-Camilo-Sanchez-Echeverri/ms-usuarios/security/code-scanning/17)

To fix the problem, we need to introduce rate limiting to the Express application. The best way to do this is by using the `express-rate-limit` package, which allows us to set up rate limiting middleware easily. We will configure the rate limiter to allow a maximum of 100 requests per 15 minutes and apply it to the router handling the `borrarCategoria` route.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `routes/categorias.js` file.
3. Set up the rate limiter with the desired configuration.
4. Apply the rate limiter to the router.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
